### PR TITLE
stop using old event loop fixture

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ dev-dependencies = [
     "coverage>=7.6.2",
     "pre-commit>=4.0.1",
     "pytest>=8.3.3",
-    "pytest-asyncio>=0.24.0",
+    "pytest-asyncio>=1.1.0",
     "ruff>=0.6.9",
     "tox>=4.21.2",
 ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,9 @@
+import asyncio
+import pytest
+
+
+@pytest.fixture()
+def asyncio_event_loop():
+    e = asyncio.new_event_loop()
+    yield e
+    e.close()

--- a/tests/test_pubsub.py
+++ b/tests/test_pubsub.py
@@ -61,8 +61,8 @@ async def test_send_receive(channel_layer):
     assert message["text"] == "Ahoy-hoy!"
 
 
-def test_send_receive_sync(channel_layer, event_loop):
-    _await = event_loop.run_until_complete
+def test_send_receive_sync(channel_layer, asyncio_event_loop):
+    _await = asyncio_event_loop.run_until_complete
     channel = _await(channel_layer.new_channel())
     async_to_sync(channel_layer.send, force_new_loop=True)(
         channel, {"type": "test.message", "text": "Ahoy-hoy!"}
@@ -86,8 +86,8 @@ async def test_multi_send_receive(channel_layer):
     assert (await channel_layer.receive(channel))["type"] == "message.3"
 
 
-def test_multi_send_receive_sync(channel_layer, event_loop):
-    _await = event_loop.run_until_complete
+def test_multi_send_receive_sync(channel_layer, asyncio_event_loop):
+    _await = asyncio_event_loop.run_until_complete
     channel = _await(channel_layer.new_channel())
     send = async_to_sync(channel_layer.send)
     send(channel, {"type": "message.1"})

--- a/tests/test_pubsub_sentinel.py
+++ b/tests/test_pubsub_sentinel.py
@@ -42,8 +42,8 @@ async def test_send_receive(channel_layer):
     assert message["text"] == "Ahoy-hoy!"
 
 
-def test_send_receive_sync(channel_layer, event_loop):
-    _await = event_loop.run_until_complete
+def test_send_receive_sync(channel_layer, asyncio_event_loop):
+    _await = asyncio_event_loop.run_until_complete
     channel = _await(channel_layer.new_channel())
     async_to_sync(channel_layer.send, force_new_loop=True)(
         channel, {"type": "test.message", "text": "Ahoy-hoy!"}
@@ -67,8 +67,8 @@ async def test_multi_send_receive(channel_layer):
     assert (await channel_layer.receive(channel))["type"] == "message.3"
 
 
-def test_multi_send_receive_sync(channel_layer, event_loop):
-    _await = event_loop.run_until_complete
+def test_multi_send_receive_sync(channel_layer, asyncio_event_loop):
+    _await = asyncio_event_loop.run_until_complete
     channel = _await(channel_layer.new_channel())
     send = async_to_sync(channel_layer.send)
     send(channel, {"type": "message.1"})


### PR DESCRIPTION
to comply with https://github.com/django/channels_redis/pull/418
and https://github.com/pytest-dev/pytest-asyncio/pull/1106